### PR TITLE
ci: switch to GitHub Release for Greasy Fork auto-sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy to GitHub Pages
+name: Build and Release
 
 on:
   push:
@@ -6,16 +6,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  build:
+  build-and-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,22 +26,35 @@ jobs:
         
       - name: Build
         run: npm run build
-        
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-        
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './dist'
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if release already exists
+        id: check_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.get_version.outputs.tag }}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release $TAG already exists, skipping"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Release $TAG does not exist, will create"
+          fi
+
+      - name: Create Release
+        if: steps.check_release.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag }}
+          name: "Release ${{ steps.get_version.outputs.version }}"
+          files: dist/MWI-Profit-Panel.user.js
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 背景

Greasy Fork 不支持 GitHub Pages 的 webhook 同步方式。它只支持两种来源：
- raw.githubusercontent.com 的原始文件 URL
- GitHub Release 的 asset URL

## 改动

将  从 **Pages 部署** 改为 **Release 上传**：

### Workflow 流程
1. 
added 332 packages, and audited 333 packages in 10s

86 packages are looking for funding
  run `npm fund` for details

8 vulnerabilities (3 moderate, 5 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details. + 
> mwi-profit-panel@2026.04.23 build
> cross-env NODE_ENV=production rollup -c 打包
2. 读取  的  字段
3. 检查是否已有对应版本的 release（通过 tag 判断）
4. **如果版本已存在** → 跳过，不重复创建
5. **如果版本不存在** → 创建新 release，上传  作为 asset

### 关键设计
- **不删除旧 release**：避免 Greasy Fork 的历史版本混乱
- **版本不变不发布**：只有当  里的 version 变化时才触发 release
- Greasy Fork 同步 URL 格式：
  

## Greasy Fork 配置步骤

1. 去 Greasy Fork 脚本管理 → 同步设置
2. **同步方式**：自动
3. **代码 URL**：
4. 复制 Greasy Fork 给的 **Webhook URL**
5. GitHub 仓库 → Settings → Webhooks → Add webhook
   - Payload URL：贴 Greasy Fork 的 webhook URL
   - Content type：
   - Events：**Release events**

这样每次 bump version 合并到 main，CI 自动发 release，Greasy Fork 收到 webhook 后自动同步。